### PR TITLE
fix: make use of the step variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ A tiny, secure, URL-friendly, unique string ID generator for Postgres.
 
 ## Use
 ```sql
-SELECT nanoid();
+SELECT nanoid(); -- creates an id, with the defaults of the created nanoid() function.
+SELECT nanoid(4); -- size parameter set to return 4 digit ids only
+SELECT nanoid(3, 'abcdefghij'); -- custom size and alphabet parameters defined. nanoid() generates ids concerning them
 ```
 
 ```sql

--- a/nanoid.sql
+++ b/nanoid.sql
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Viascom Ltd liab. Co
+ * Copyright 2023 Viascom Ltd liab. Co
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -21,36 +21,43 @@
 
 CREATE EXTENSION IF NOT EXISTS pgcrypto;
 
-CREATE OR REPLACE FUNCTION nanoid(size int DEFAULT 21, alphabet text DEFAULT '_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
+CREATE OR REPLACE FUNCTION nanoid(
+    size int DEFAULT 21,
+    alphabet text DEFAULT '_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+)
     RETURNS text
     LANGUAGE plpgsql
     volatile
 AS
 $$
 DECLARE
-    idBuilder     text := '';
-    i             int  := 0;
-    bytes         bytea;
-    alphabetIndex int;
-    mask          int;
-    step          int;
+    idBuilder      text := '';
+    i              int  := 0;
+    bytes          bytea;
+    alphabetIndex  int;
+    mask           int;
+    step           int;
+    alphabetArray  text[];
+    alphabetLength int;
 BEGIN
-    mask := (2 << cast(floor(log(length(alphabet) - 1) / log(2)) as int)) - 1;
-    step := cast(ceil(1.6 * mask * size / length(alphabet)) AS int);
+    alphabetArray := regexp_split_to_array(alphabet, '');
+    alphabetLength := array_length(alphabetArray, 1);
+    mask := (2 << cast(floor(log(alphabetLength - 1) / log(2)) as int)) - 1;
+    step := cast(ceil(1.6 * mask * size / alphabetLength) AS int);
 
     while true
         loop
-            bytes := gen_random_bytes(size);
-            while i < size
+            bytes := gen_random_bytes(step);
+            while i < step
                 loop
                     alphabetIndex := (get_byte(bytes, i) & mask) + 1;
-                    if alphabetIndex <= length(alphabet) then
-                        idBuilder := idBuilder || substr(alphabet, alphabetIndex, 1);
+                    if alphabetIndex <= alphabetLength then
+                        idBuilder := idBuilder || alphabetArray[alphabetIndex];
                         if length(idBuilder) = size then
                             return idBuilder;
                         end if;
                     end if;
-                    i = i + 1;
+                    i := i + 1;
                 end loop;
 
             i := 0;

--- a/nanoid.sql
+++ b/nanoid.sql
@@ -32,13 +32,13 @@ AS
 $$
 DECLARE
     idBuilder      text := '';
-    i              int  := 0;
+    counter        int  := 0;
     bytes          bytea;
     alphabetIndex  int;
-    mask           int;
-    step           int;
     alphabetArray  text[];
     alphabetLength int;
+    mask           int;
+    step           int;
 BEGIN
     alphabetArray := regexp_split_to_array(alphabet, '');
     alphabetLength := array_length(alphabetArray, 1);
@@ -48,19 +48,19 @@ BEGIN
     while true
         loop
             bytes := gen_random_bytes(step);
-            while i < step
+            while counter < step
                 loop
-                    alphabetIndex := (get_byte(bytes, i) & mask) + 1;
+                    alphabetIndex := (get_byte(bytes, counter) & mask) + 1;
                     if alphabetIndex <= alphabetLength then
                         idBuilder := idBuilder || alphabetArray[alphabetIndex];
                         if length(idBuilder) = size then
                             return idBuilder;
                         end if;
                     end if;
-                    i := i + 1;
+                    counter := counter + 1;
                 end loop;
 
-            i := 0;
+            counter := 0;
         end loop;
 END
 $$;


### PR DESCRIPTION
fix: make use of the step variable, which determines how many random bytes to generate. The number of random bytes gets decided upon the ID size, mask, alphabet size, and magic number 1.6 (using 1.6 peaks at performance according to benchmarks).

source: https://github.com/ai/nanoid/blob/main/index.browser.js