### PR TITLE
Add parallel unsafe indication

### DIFF
--- a/nanoid.sql
+++ b/nanoid.sql
@@ -28,6 +28,7 @@ CREATE OR REPLACE FUNCTION nanoid(
     RETURNS text
     LANGUAGE plpgsql
     volatile
+    PARALLEL UNSAFE
 AS
 $$
 DECLARE


### PR DESCRIPTION
Hey there, 
First of all, thank you for this function. It was exactly what I needed 😄 

I've noticed that using `nanoid` with more than 20 rows might get stuck on my Postgres instance. After researching, I discovered that adding a `PARALLEL UNSAFE` indication can fix the issue. From the [docs](https://www.postgresql.org/docs/10/sql-createfunction.html#:~:text=only%20external%20ones.-,PARALLEL,-PARALLEL%20UNSAFE%20indicates): `PARALLEL UNSAFE` indicates that the function can't be executed in parallel mode and the presence of such a function in an SQL statement forces a serial execution plan. 

Issue link: https://github.com/viascom/nanoid-postgres/issues/9